### PR TITLE
Patch American DSi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # hiyalang
-# hiyalang
 HiyaCFW Launcher language patcher for Windows
 ## Installation
 1. Put the file hiyalang.exe into the root of your sd card

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # hiyalang
+# hiyalang
 HiyaCFW Launcher language patcher for Windows
-
+## Installation
+1. Put the file hiyalang.exe into the root of your sd card
+2. Double click on the just copied "hiyalang.exe" file. When it is finished press enter
+3. You are done. Please put your sd card back into your Nintendo DSi
 ## Features:
+* Changes your Nintendo DSi CFW region from Chinese, Japan, Korean or American to European, which adds new language options
 * Fixed file name check
 * Auto backup creation
-* CHN/JPN/KOR/AmericatoEUR patch
-
 ## Known bugs:
 * Camera app not working - reinstall HiyaCFW
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ HiyaCFW Launcher language patcher for Windows
 ## Features:
 * Fixed file name check
 * Auto backup creation
-* CHN/JPN/KORtoEUR patch
+* CHN/JPN/KOR/AmericatoEUR patch
 
 ## Known bugs:
 * Camera app not working - reinstall HiyaCFW

--- a/hiyalang.dpr
+++ b/hiyalang.dpr
@@ -38,7 +38,8 @@ const
   LocalFileArr: Array[0..1] of String = (
     '00000000.app', '00000002.app'
   );
-  AppFileArray: Array[0..2] of Array[0..2] of String = (
+  AppFileArray: Array[0..3] of Array[0..2] of String = (
+    ('5', '2', 'USA'),
     ('3', '0', 'Chinese'),
     ('a', '2', 'Japanese'),
     ('b', '0', 'Korean')

--- a/hiyalang.dpr
+++ b/hiyalang.dpr
@@ -1,6 +1,7 @@
 {
-  v0.4 @ 11.07.2021
+  v0.5 @ 06.02.2022
   This patcher utility is written by Yoti
+  American region support added by Simonsator
   Mostly based on Mighty Max's work - thx
 }
 {

--- a/hiyalang.dpr
+++ b/hiyalang.dpr
@@ -40,8 +40,8 @@ const
     '00000000.app', '00000002.app'
   );
   AppFileArray: Array[0..3] of Array[0..2] of String = (
-    ('5', '2', 'USA'),
     ('3', '0', 'Chinese'),
+    ('5', '2', 'USA'),
     ('a', '2', 'Japanese'),
     ('b', '0', 'Korean')
   );


### PR DESCRIPTION
This commit adds patches for American region DSi systems, which does change them to an European DSi (only emunand, not nand). This allows users to set the language to German, which is not possible with the American Region.

I also added installation instructions to the readme file.